### PR TITLE
feat: add `/cfp` CFP Guidance page

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -32,6 +32,8 @@
 		"squiggleconf",
 		"tseslint",
 		"vercel",
+		"WASI",
+		"WCAG",
 		"wght-italic"
 	]
 }

--- a/src/components/BodyList.astro
+++ b/src/components/BodyList.astro
@@ -1,0 +1,19 @@
+---
+const { as: As, class: className, ...rest } = Astro.props;
+---
+
+<As class:list={[className, "body-list"]} {...rest}>
+	<slot />
+</As>
+
+<style>
+	.body-list {
+		margin: 0 1rem;
+		font-size: var(--fontSizeSmall);
+		font-weight: var(--fontWeightMedium);
+	}
+
+	.body-list li {
+		padding-left: 1rem; /* TODO: WHY NO WORK?! */
+	}
+</style>

--- a/src/components/BodyList.astro
+++ b/src/components/BodyList.astro
@@ -12,8 +12,4 @@ const { as: As, class: className, ...rest } = Astro.props;
 		font-size: var(--fontSizeSmall);
 		font-weight: var(--fontWeightMedium);
 	}
-
-	.body-list li {
-		padding-left: 1rem; /* TODO: WHY NO WORK?! */
-	}
 </style>

--- a/src/components/CommonContent.astro
+++ b/src/components/CommonContent.astro
@@ -5,13 +5,14 @@ import Heading from "./Heading.astro";
 interface Props {
 	class?: string;
 	heading: string;
+	level?: "h2" | "h3";
 }
 
-const { class: className, ...rest } = Astro.props;
+const { class: className, level = "h2", ...rest } = Astro.props;
 ---
 
 <ContentArea class:list={["common-content", className]} width="thin" {...rest}>
-	<Heading level="h2">{Astro.props.heading}</Heading>
+	<Heading level={level}>{Astro.props.heading}</Heading>
 	<slot />
 </ContentArea>
 
@@ -28,11 +29,19 @@ const { class: className, ...rest } = Astro.props;
 		padding-top: 0;
 	}
 
-	h2 {
+	h2,
+	h3 {
 		color: var(--colorForegroundEmphasized);
-		font-size: var(--fontSizeLarge);
 		font-family: var(--fontFamilyLogo);
 		padding-bottom: 2rem;
 		text-align: center;
+	}
+
+	h2 {
+		font-size: var(--fontSizeLarge);
+	}
+
+	h3 {
+		font-size: var(--fontSizeMedium);
 	}
 </style>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -8,6 +8,7 @@ function hrefProps(pathname: string) {
 	return {
 		class: Astro.url.pathname === pathname ? "" : "header-link-inactive",
 		href: pathname,
+		target: pathname.startsWith("https") ? "_blank" : undefined,
 	};
 }
 ---
@@ -20,6 +21,7 @@ function hrefProps(pathname: string) {
 			<summary aria-label="Toggle header">≡</summary>
 			<div class="header-contents-mobile">
 				<a {...hrefProps("/")}>Home</a>
+				<a {...hrefProps("/cfp")}>CFP</a>
 				<a {...hrefProps(links.shop)}>Shop</a>
 				<a {...hrefProps("/travel")}>Travel</a>
 				<Button
@@ -37,6 +39,7 @@ function hrefProps(pathname: string) {
 		<a class="logo" href="/"><Logo year /></a>
 		<div class="header-links">
 			<a {...hrefProps("/")}>Home</a>
+			<a {...hrefProps("/cfp")}>CFP</a>
 			<a {...hrefProps(links.shop)}>Shop</a>
 			<a {...hrefProps("/travel")}>Travel</a>
 			<Button
@@ -76,9 +79,10 @@ function hrefProps(pathname: string) {
 	}
 
 	.header-content-area-mobile {
+		align-items: center;
 		display: flex;
 		justify-content: space-between;
-		align-items: center;
+		position: relative;
 	}
 
 	details {
@@ -95,8 +99,11 @@ function hrefProps(pathname: string) {
 		cursor: pointer;
 		font-size: 4rem;
 		list-style: none;
-		padding: 0 1rem;
-		position: relative;
+		line-height: 0;
+		padding: 1rem;
+		position: absolute;
+		right: 0;
+		top: 0;
 		z-index: 2;
 	}
 
@@ -116,7 +123,7 @@ function hrefProps(pathname: string) {
 		font-weight: bold;
 		gap: 0.5rem;
 		line-height: 1.5;
-		margin-top: calc(var(--offsetTop) * -1);
+		margin-top: 0;
 		min-width: 20rem;
 		padding: var(--offsetTop) 1rem 1.5rem;
 		position: absolute;
@@ -151,7 +158,7 @@ function hrefProps(pathname: string) {
 		margin-left: 0.35rem;
 	}
 
-	@media (width >= 819px) {
+	@media (width >= 1017px) {
 		.header-content-area-mobile {
 			display: none;
 		}

--- a/src/components/explainers/ExplainersList.astro
+++ b/src/components/explainers/ExplainersList.astro
@@ -21,10 +21,10 @@ import ExplainerArea from "./ExplainerArea.astro";
 
 const explainers = [
 	{
-		// action: {
-		// 	href: "https://cfp.squiggleconf.com",
-		// 	text: "Apply to be a speaker! CFP now open!",
-		// },
+		action: {
+			href: "https://cfp.squiggleconf.com",
+			text: "Apply to be a speaker! CFP now open!",
+		},
 		body: "Enjoy a dozen talks by tooling aficionados, dev experts, and new voices in the space. You’ll emerge with the best techniques to supercharge your projects.",
 		decoration: DolphinDecoration,
 		direction: "up",

--- a/src/components/hero/HeroContentsStandard.astro
+++ b/src/components/hero/HeroContentsStandard.astro
@@ -4,11 +4,12 @@ import TextSquiggly from "~/components/TextSquiggly.astro";
 
 interface Props {
 	heading: string;
+	squiggly?: "medium" | "wide";
 }
 ---
 
 <div class="hero-contents-standard">
-	<TextSquiggly width="medium">
+	<TextSquiggly width={Astro.props.squiggly ?? "medium"}>
 		<Heading level="h1" slot="inside">{Astro.props.heading}</Heading>
 	</TextSquiggly>
 

--- a/src/components/hero/HeroContentsStandard.astro
+++ b/src/components/hero/HeroContentsStandard.astro
@@ -6,10 +6,14 @@ interface Props {
 	heading: string;
 	squiggly?: "medium" | "wide";
 }
+
+const { heading, squiggly = "medium" }: Props = Astro.props;
 ---
 
-<div class="hero-contents-standard">
-	<TextSquiggly width={Astro.props.squiggly ?? "medium"}>
+<div
+	class:list={["hero-contents-standard", `hero-contents-standard-${squiggly}`]}
+>
+	<TextSquiggly width={squiggly}>
 		<Heading level="h1" slot="inside">{Astro.props.heading}</Heading>
 	</TextSquiggly>
 
@@ -32,6 +36,10 @@ interface Props {
 	h1 {
 		font-size: var(--fontSizeHero);
 		font-weight: var(--fontWeightMedium);
+	}
+
+	.hero-contents-standard-wide h1 {
+		padding-bottom: 0.25rem;
 	}
 
 	.hero-contents-standard-body {

--- a/src/data/links.ts
+++ b/src/data/links.ts
@@ -1,4 +1,8 @@
 export const links = {
+	cfp: "https://cfp.squiggleconf.com",
+	cfpQuestionsDiscord:
+		"https://discord.com/channels/1181983343387099207/1244808425762848938",
+	cfpQuestionsEmail: "mailto:cfp@squiggleconf.com",
 	shop: "https://shop.squiggle.tools",
 	tickets: "https://buytickets.at/squiggleconf/1488622",
 };

--- a/src/pages/cfp-guidance.astro
+++ b/src/pages/cfp-guidance.astro
@@ -1,0 +1,251 @@
+---
+import Arrow from "~/components/Arrow.astro";
+import BodyList from "~/components/BodyList.astro";
+import BodyText from "~/components/BodyText.astro";
+import Button from "~/components/Button.astro";
+import CommonContent from "~/components/CommonContent.astro";
+import Hero from "~/components/hero/Hero.astro";
+import HeroContentsStandard from "~/components/hero/HeroContentsStandard.astro";
+import { links } from "~/data/links";
+import PageLayout from "~/layouts/PageLayout.astro";
+
+const description =
+	"Advice and general information for submitting talks to SquiggleConf 2025";
+---
+
+<PageLayout description={description} title="CFP Guidance">
+	<Hero>
+		<HeroContentsStandard heading="CFP Guidance" squiggly="wide">
+			{description}
+		</HeroContentsStandard>
+	</Hero>
+
+	<CommonContent heading="We Appreciate You">
+		<BodyText>
+			Thank you so much for your interest in submitting a speak at SquiggleConf
+			2025! This page is a general guide for what you can expect in submitting,
+			including tips for what we're looking for.
+		</BodyText>
+
+		<Button
+			as="a"
+			class="apply-button apply-button-top"
+			size="large"
+			variant="emphasized"
+			href={links.cfp}
+			target="_blank"
+		>
+			Apply to the CFP here!
+			<Arrow />
+		</Button>
+	</CommonContent>
+
+	<CommonContent heading="The Highlights">
+		<BodyList as="ul">
+			<li>
+				<strong>📆 Deadline:</strong> We are accepting submissions through May 23rd.
+				You'll hear from us by June 9th.
+			</li>
+			<li>
+				<strong>🤝 Acceptance:</strong> If we accept your talk, we'll ask you to
+				confirm within 7 days of hearing from us.
+			</li>
+			<li>
+				<strong>❤️ Experience:</strong> Speakers of all experience levels, including
+				first-timers, are encouraged to apply.
+			</li>
+			<li>
+				<strong>👍 Expectations:</strong> Giving us a remote dry run of a rough draft
+				of your talk the week before the conference.
+			</li>
+		</BodyList>
+	</CommonContent>
+
+	<CommonContent heading="CFP Timeline">
+		<BodyText>We will respond to every talk proposal submitted.</BodyText>
+		<br />
+		<BodyList as="ul">
+			<li>
+				<strong>March 3rd:</strong> CFP opens
+			</li>
+			<li>
+				<strong>May 23rd:</strong> CFP closes
+			</li>
+			<li>
+				<strong>June 9th:</strong> All CFP submitters will have heard back from us
+			</li>
+		</BodyList>
+		<br />
+		<BodyText>
+			If we accept your submission, we will expect you to accept or reject our
+			invitation within a week of hearing from us.
+		</BodyText>
+		<br />
+		<BodyText>
+			We will create a "marketing title" for your talk with you that will be
+			used to advertise your talk. There may be a completely different title
+			used for the YouTube video.
+		</BodyText>
+	</CommonContent>
+
+	<CommonContent heading="Speaker Expectations">
+		<BodyText>
+			Speakers will receive information regarding a speaker/sponsor dinner, a
+			speakers-only private event, opportunities to hang out during the
+			conference, and any volunteer needs.
+		</BodyText>
+		<br />
+		<BodyList as="ul">
+			<li>
+				<strong>
+					We require a dry run of a final draft of your presentation the week
+					before the conference.
+				</strong>
+				This will help us check talks for accessibility best practices.
+			</li>
+			<li>
+				<strong>September 5th</strong>: Deadline for RSVPing to the
+				speaker+sponsor dinner and speaker+organizer activity
+			</li>
+			<li>
+				<strong>October 10th</strong>: Deadline to submit travel receipts for
+				reimbursement
+			</li>
+		</BodyList>
+	</CommonContent>
+
+	<CommonContent heading="Tips and Tricks">
+		<BodyText>
+			We suggest reading <a
+				href="https://www.joshuakgoldberg.com/blog/how-i-apply-to-conferences/?utm-source=squiggleconfcfp"
+				target="_blank">this CFP help guide</a
+			> for an overview of how to submit to a CFP.
+		</BodyText>
+	</CommonContent>
+
+	<CommonContent heading="Asking for Help" level="h3">
+		<BodyText>
+			We're always happy to give advice and generally help in submitting to the
+			CFP! There are no "dumb" questions.
+		</BodyText>
+		<br />
+		<BodyText>
+			Please don't hesitate to reach out to <a
+				href={links.cfpQuestionsEmail}
+				target="_blank">cfp@squiggleconf.com</a
+			> or on Discord in the <a href={links.cfpQuestionsDiscord} target="_blank"
+				>#cfp-questions</a
+			> channel.
+		</BodyText>
+	</CommonContent>
+
+	<CommonContent heading="Timing" level="h3">
+		<BodyText>
+			We don't factor in how early or late a CFP is submitted. We recommend not
+			procrastinating until the last minute, so you don't forget to submit.
+		</BodyText>
+	</CommonContent>
+
+	<CommonContent heading="Topic Suggestions" level="h3">
+		<BodyText>
+			We plan on including at least one talk in each of the following
+			categories:
+		</BodyText>
+
+		<br />
+		<BodyList as="ul">
+			<li><strong>Accessibility:</strong> WCAG, web accessibility, etc.</li>
+			<li><strong>Building:</strong> CLI Tools, monorepo management</li>
+			<li>
+				<strong>Documentation:</strong> Writing docs, tools to manage and/or share
+				them, explaining code
+			</li>
+			<li>
+				<strong>Editors:</strong> Tools such as IDEs along with integrations and
+				plugins built on them
+			</li>
+			<li>
+				<strong>Performance:</strong> Enhancing performance of apps, sites, or any
+				web dev tools
+			</li>
+			<li>
+				<strong>Testing:</strong> The art of verifying code, or building tools to
+				help developers test
+			</li>
+			<li>
+				<strong>TypeScript:</strong> Integrating, working with, or even contributing
+				to our favorite JS superset
+			</li>
+			<li>
+				<strong>Rust:</strong> Working in Rust for the purposes of web dev apps and/or
+				tooling
+			</li>
+			<li>
+				<strong>Go and/or Zig:</strong> Using the popular low-level language for
+				web development and/or tooling
+			</li>
+			<li>
+				<strong>WebAssembly:</strong> Tooling or usage of WebAssembly/WASI/WASM
+			</li>
+			<li>
+				<strong>Other:</strong> Something incredible or something fun. We really
+				care about having off-the-beaten-tail fun things. Extra bonus points if it’s
+				visual.
+			</li>
+		</BodyList>
+		<br />
+		<BodyText>
+			We also hope to have talks that cover the following subjects:
+		</BodyText>
+		<br />
+		<BodyList as="ul">
+			<li>
+				<strong>Open Source:</strong> The making, maintenance, release, and socialization
+				of shared software
+			</li>
+			<li>
+				<strong>Runtimes:</strong> Execution environments such as Bun, Deno, and
+				Node.js
+			</li>
+		</BodyList>
+		<br />
+		<BodyText> We don't plan to emphasize the following subjects: </BodyText>
+		<br />
+		<BodyList as="ul">
+			<li>
+				<strong>AI:</strong> We are happy to have AI mentioned in a talk, but its
+				focus should be dev tooling.
+			</li>
+			<li>
+				<strong>Blockchain:</strong> We will almost definitely not accept this talk.
+			</li>
+		</BodyList>
+
+		<Button
+			as="a"
+			class="apply-button apply-button-bottom"
+			size="large"
+			variant="emphasized"
+			href={links.cfp}
+			target="_blank"
+		>
+			Apply to the CFP here!
+			<Arrow />
+		</Button>
+	</CommonContent>
+</PageLayout>
+
+<style>
+	.apply-button {
+		margin: auto;
+		gap: 0.5rem;
+	}
+
+	.apply-button-top {
+		margin-top: 2rem;
+	}
+
+	.apply-button-bottom {
+		margin: 3.5rem auto 0;
+	}
+</style>

--- a/src/pages/cfp.astro
+++ b/src/pages/cfp.astro
@@ -13,9 +13,9 @@ const description =
 	"Advice and general information for submitting talks to SquiggleConf 2025";
 ---
 
-<PageLayout description={description} title="CFP Guidance">
+<PageLayout description={description} title="Call for Proposals">
 	<Hero>
-		<HeroContentsStandard heading="CFP Guidance" squiggly="wide">
+		<HeroContentsStandard heading="Call for Proposals" squiggly="wide">
 			{description}
 		</HeroContentsStandard>
 	</Hero>

--- a/src/pages/cfp.astro
+++ b/src/pages/cfp.astro
@@ -11,6 +11,44 @@ import PageLayout from "~/layouts/PageLayout.astro";
 
 const description =
 	"Advice and general information for submitting talks to SquiggleConf 2025";
+
+const topicAreas = [
+	[`Accessibility`, `the accessibility tree, WCAG, web accessibility`],
+	[`Building`, `CLI tools, deployments, monorepo management`],
+	[
+		`Documentation`,
+		`Writing docs, tools to manage and/or share them, explaining code`,
+	],
+	[
+		`Editors`,
+		`Tools such as IDEs along with integrations and plugins built on them`,
+	],
+	[
+		`Go and/or Zig`,
+		`Using the popular low-level languages for web development and/or tooling`,
+	],
+	[
+		`Open Source`,
+		`The making, maintenance, release, and socialization of shared software`,
+	],
+	[`Performance`, `Enhancing performance of apps, sites, or any web dev tools`],
+	[`Runtimes`, `Execution environments such as Bun, Deno, and Node.js`],
+	[`Rust`, `Working in Rust for the purposes of web dev apps and/or tooling`],
+	[
+		`Testing`,
+		`The art of verifying code, or building tools to help developers test`,
+	],
+	[`Tooling`, `Debuggers, integrations, and general dev tools themselves`],
+	[
+		`TypeScript`,
+		`Integrating, working with, or even contributing to our favorite JS superset`,
+	],
+	[`WebAssembly`, `Tooling or usage of WebAssembly/WASI/WASM`],
+	[
+		`Other`,
+		`Something fun or incredible. We love off-the-beaten-tail fun things.`,
+	],
+];
 ---
 
 <PageLayout description={description} title="Call for Proposals">
@@ -40,7 +78,7 @@ const description =
 		</Button>
 	</CommonContent>
 
-	<CommonContent heading="The Highlights">
+	<CommonContent heading="CFP Highlights">
 		<BodyList as="ul">
 			<li>
 				<strong>📆 Deadline:</strong> We are accepting submissions through May 23rd.
@@ -57,6 +95,25 @@ const description =
 			<li>
 				<strong>👍 Expectations:</strong> Giving us a remote dry run of a rough draft
 				of your talk the week before the conference.
+			</li>
+		</BodyList>
+	</CommonContent>
+
+	<CommonContent heading="Conference Details" level="h3">
+		<BodyList as="ul">
+			<li>
+				<strong>🗺️ Time & Place:</strong> Thursday & Friday September 18th & 19th
+				in Boston, Massachusetts. The Simons Theater at the New England Aquarium,
+				right on the ocean coastline in the very center of downtown Boston.
+			</li>
+			<li>
+				<strong>🗣️ Format:</strong> In-person, either a 30 minute talk + 5 minutes
+				for audience questions, or a 10 minute lightning talk.
+			</li>
+			<li>
+				<strong>✈️ Covered:</strong> We can cover travel and accommodations for speakers,
+				though we have a limited budget and prefer companies to pay if possible.
+				We can work with you.
 			</li>
 		</BodyList>
 	</CommonContent>
@@ -153,71 +210,28 @@ const description =
 		</BodyText>
 
 		<br />
+
 		<BodyList as="ul">
-			<li><strong>Accessibility:</strong> WCAG, web accessibility, etc.</li>
-			<li><strong>Building:</strong> CLI Tools, monorepo management</li>
-			<li>
-				<strong>Documentation:</strong> Writing docs, tools to manage and/or share
-				them, explaining code
-			</li>
-			<li>
-				<strong>Editors:</strong> Tools such as IDEs along with integrations and
-				plugins built on them
-			</li>
-			<li>
-				<strong>Performance:</strong> Enhancing performance of apps, sites, or any
-				web dev tools
-			</li>
-			<li>
-				<strong>Testing:</strong> The art of verifying code, or building tools to
-				help developers test
-			</li>
-			<li>
-				<strong>TypeScript:</strong> Integrating, working with, or even contributing
-				to our favorite JS superset
-			</li>
-			<li>
-				<strong>Rust:</strong> Working in Rust for the purposes of web dev apps and/or
-				tooling
-			</li>
-			<li>
-				<strong>Go and/or Zig:</strong> Using the popular low-level language for
-				web development and/or tooling
-			</li>
-			<li>
-				<strong>WebAssembly:</strong> Tooling or usage of WebAssembly/WASI/WASM
-			</li>
-			<li>
-				<strong>Other:</strong> Something incredible or something fun. We really
-				care about having off-the-beaten-tail fun things. Extra bonus points if it’s
-				visual.
-			</li>
-		</BodyList>
-		<br />
-		<BodyText>
-			We also hope to have talks that cover the following subjects:
-		</BodyText>
-		<br />
-		<BodyList as="ul">
-			<li>
-				<strong>Open Source:</strong> The making, maintenance, release, and socialization
-				of shared software
-			</li>
-			<li>
-				<strong>Runtimes:</strong> Execution environments such as Bun, Deno, and
-				Node.js
-			</li>
+			{
+				topicAreas.map(([topic, description]) => (
+					<li>
+						<strong>{topic}:</strong> {description}
+					</li>
+				))
+			}
 		</BodyList>
 		<br />
 		<BodyText> We don't plan to emphasize the following subjects: </BodyText>
 		<br />
 		<BodyList as="ul">
 			<li>
-				<strong>AI:</strong> We are happy to have AI mentioned in a talk, but its
-				focus should be dev tooling.
+				<strong>AI:</strong> We absolutely welcome AI being in your talk, but the
+				primary topic(s) should be centered on a dev tooling category such as one
+				our suggested ones.
 			</li>
 			<li>
-				<strong>Blockchain:</strong> We will almost definitely not accept this talk.
+				<strong>Blockchain/Crypto/NFTs:</strong> We doubt these will be applicable
+				and useful, but we are open minded and welcome you to make your case.
 			</li>
 		</BodyList>
 


### PR DESCRIPTION
## Overview

Adds a `/cfp` page that explains more details around the CFP.
