### PR TITLE
feat: add /schedule page

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -15,6 +15,7 @@
 		"astropub",
 		"astrojs",
 		"Bluesky",
+		"d'œuvres",
 		"Devries",
 		"dimitri",
 		"Emscripten",

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -152,7 +152,7 @@ function hrefProps(pathname: string) {
 		display: flex;
 		align-items: center;
 		font-weight: var(--fontWeightLight);
-		gap: clamp(0.75rem, 1.5vw, 2rem);
+		gap: clamp(0.55rem, 1.25vw, 2rem);
 	}
 
 	.header-link-inactive {
@@ -162,9 +162,10 @@ function hrefProps(pathname: string) {
 	.header-button {
 		justify-content: center;
 		margin-left: 0.35rem;
+		text-wrap: nowrap;
 	}
 
-	@media (width >= 1017px) {
+	@media (width >= 1117px) {
 		.header-content-area-mobile {
 			display: none;
 		}

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -24,6 +24,7 @@ function hrefProps(pathname: string) {
 				<a {...hrefProps("/articles")}>Articles</a>
 				<a {...hrefProps("/cfp")}>CFP</a>
 				<a {...hrefProps("/faqs")}>FAQs</a>
+				<a {...hrefProps("/schedule")}>Schedule</a>
 				<a {...hrefProps(links.shop)}>Shop</a>
 				<a {...hrefProps("/travel")}>Travel</a>
 				<Button
@@ -44,6 +45,7 @@ function hrefProps(pathname: string) {
 			<a {...hrefProps("/articles")}>Articles</a>
 			<a {...hrefProps("/cfp")}>CFP</a>
 			<a {...hrefProps("/faqs")}>FAQs</a>
+			<a {...hrefProps("/schedule")}>Schedule</a>
 			<a {...hrefProps(links.shop)}>Shop</a>
 			<a {...hrefProps("/travel")}>Travel</a>
 			<Button

--- a/src/components/ScheduledActivity.astro
+++ b/src/components/ScheduledActivity.astro
@@ -1,0 +1,141 @@
+---
+import { markdown } from "@astropub/md";
+
+import { ActivityLocation } from "~/data/schedule";
+
+import Heading from "./Heading.astro";
+import Arrow from "./Arrow.astro";
+
+interface Props {
+	at?: string;
+	description?: string[];
+	id?: string;
+	location?: ActivityLocation;
+	class?: string;
+	level?: "h3" | "h4";
+	title: string;
+}
+
+const {
+	at,
+	class: className,
+	description = [],
+	id,
+	location,
+	level = "h3",
+	title,
+	...rest
+} = Astro.props;
+
+const descriptionLines = await Promise.all(
+	description.map(async (p) => await markdown(p)),
+);
+---
+
+<div
+	class:list={["scheduled-activity", "scheduled-activity-h3", className]}
+	id={id}
+	{...rest}
+>
+	<Heading level={level} class="activity-title">
+		{title}
+	</Heading>
+	<div class="activity-locators">
+		<div class="activity-time">{at ?? "Time TBA"}</div>
+		{
+			location && (
+				<a class="activity-location" href={location.href}>
+					{location.text}
+				</a>
+			)
+		}
+	</div>
+	{
+		descriptionLines && (
+			<div class="activity-description">{descriptionLines}</div>
+		)
+	}
+</div>
+
+<style>
+	.scheduled-activity {
+		font-weight: var(--fontWeightLight);
+		margin: 0 var(--widthBodyPadding);
+		max-width: var(--widthBodyLean);
+		scroll-margin-top: 2rem;
+	}
+
+	.scheduled-activity-h3 {
+		margin-top: 2rem;
+	}
+
+	.activity-title {
+		font-family: var(--fontFamilyLogo);
+		font-size: var(--fontSizeMedium);
+		font-weight: var(--fontWeightLogo);
+		text-decoration: none;
+	}
+
+	.activity-title-inner {
+		display: inline;
+	}
+
+	.activity-locators {
+		display: flex;
+		font-family: var(--fontFamilyLogo);
+		font-weight: var(--fontWeightSemibold);
+		gap: 0.75rem;
+		justify-content: space-between;
+		margin: 0.5rem 0;
+	}
+
+	.activity-time {
+		font-size: var(--fontSizeMedium);
+	}
+
+	.activity-location {
+		line-height: 1.25;
+		text-align: right;
+	}
+
+	.activity-description {
+		display: flex;
+		gap: 0.5rem;
+		flex-direction: column;
+		width: 100%;
+	}
+
+	.activity-within {
+		list-style: none;
+		padding-left: 0;
+	}
+
+	@media (min-width: 490px) {
+		.scheduled-activity {
+			display: grid;
+			grid-template-columns: clamp(5rem, 20vw, 10rem) auto;
+			grid-template-rows: auto auto auto;
+			gap: 0.75rem 1rem;
+		}
+
+		.activity-title {
+			grid-area: 1 / 2 / 2 / 3;
+		}
+
+		.activity-locators {
+			grid-area: 1 / 1 / 3 / 2;
+			flex-direction: column;
+			margin: 0;
+			justify-content: flex-start;
+			text-align: right;
+		}
+
+		.activity-description {
+			grid-area: 2 / 2 / 3 / 3;
+		}
+
+		.activity-within {
+			grid-area: 3 / 1 / 4 / 3;
+		}
+	}
+</style>

--- a/src/data/schedule.ts
+++ b/src/data/schedule.ts
@@ -133,11 +133,21 @@ export const days: ScheduleDay[] = [
 				title: "Closing Announcements",
 			},
 			{
-				at: "6:00pm",
+				at: "5:00pm",
+				description: [
+					"Split up into small groups and race to take pictures of historic Boston landmarks as a team.",
+					"We'll provide a list of locations and a map to help you navigate at the end of the closing announcements.",
+					"Prizes will include SquiggleConf swag and free tickets to next year's conference.",
+				],
+				title: "Photo Challenge",
+			},
+			{
+				// todo: switch to string[] for less prominent &
+				at: "6:00pm & 7:00pm",
 				description: [
 					"We'll arrange suggested dinner and casual social gathering locations for attendees.",
 				],
-				title: "Casual Mid-Conference Suggestions",
+				title: "Suggested Dinner Locations",
 			},
 		],
 		title: "Thursday, September 18th",

--- a/src/data/schedule.ts
+++ b/src/data/schedule.ts
@@ -1,0 +1,253 @@
+export interface ActivityBetweenData extends ActivityDataWithinBase {
+	title: string;
+	type: "between";
+}
+
+export interface ActivityData {
+	at?: string;
+	description: string[];
+	location?: ActivityLocation;
+	title: string;
+	within?: ActivityDataWithin[];
+}
+
+export type ActivityDataWithin = ActivityBetweenData | ActivitySessionData;
+
+export interface ActivityDataWithinBase {
+	at: string;
+}
+
+export interface ActivityLocation {
+	href: string;
+	text: string;
+}
+
+export interface ActivitySessionData extends ActivityDataWithinBase {
+	session: string;
+	type: "session";
+}
+
+export interface ScheduleDay {
+	activities: ActivityData[];
+	title: string;
+}
+
+export const days: ScheduleDay[] = [
+	{
+		activities: [
+			{
+				at: "Afternoon",
+				description: [
+					"We will arrange a volunteering event with a local non-profit the afternoon before the conference.",
+					`This event will free and open to any attendee who can code in at least HTML.`,
+				],
+				title: " Volunteering Event",
+			},
+		],
+		title: "Wednesday, September 17th",
+	},
+	{
+		activities: [
+			{
+				at: "7:00am",
+				description: [
+					"Join organizers, volunteers, and attendees for a free joyful jog around the Boston harbor.",
+					"We'll meet at the New England Aquarium and run in a 5k loop at a comfortably light pace.",
+				],
+				location: {
+					href: "https://www.neaq.org/visit",
+					text: "New England Aquarium",
+				},
+				title: "Morning Fun Run",
+			},
+			{
+				at: "8:45am",
+				description: [
+					"Come over to the venue, collect your badge, and network with fellow attendees.",
+				],
+				location: {
+					href: "https://www.neaq.org/visit/simons-theatre",
+					text: "Simons Theater",
+				},
+				title: "Doors Open",
+			},
+			{
+				at: "10:00am",
+				description: ["Full-length and lightning talks from our speakers."],
+				location: {
+					href: "https://www.neaq.org/visit/simons-theatre",
+					text: "Simons Theater",
+				},
+				title: "Talks",
+			},
+			{
+				at: "12:30pm",
+				description: [
+					"Head over to the nearby Faneuil Hall Marketplace for lunch.",
+					"We'll have volunteers available to bring groups to and from popular food establishments.",
+				],
+				location: {
+					href: "https://faneuilhallmarketplace.com",
+					text: "Faneuil Hall Marketplace",
+				},
+				title: "Lunch",
+			},
+			{
+				at: "2:15pm",
+				description: ["Full-length and lightning talks from our speakers."],
+				location: {
+					href: "https://www.neaq.org/visit/simons-theatre",
+					text: "Simons Theater",
+				},
+				title: "Talks",
+			},
+			{
+				at: "3:45pm",
+				description: [
+					"What a day! Let's take a breather to have a snack and chat.",
+				],
+				location: {
+					href: "https://www.neaq.org/visit/simons-theatre",
+					text: "Simons Theater",
+				},
+				title: "Afternoon Snack",
+			},
+			{
+				at: "4:00pm",
+				description: ["Full-length and lightning talks from our speakers."],
+				location: {
+					href: "https://www.neaq.org/visit/simons-theatre",
+					text: "Simons Theater",
+				},
+				title: "Talks",
+			},
+			{
+				at: "4:45pm",
+				description: [
+					"Final pieces of information on upcoming events, raffle giveaways, and appreciation notes to all of the lovely people who attended.",
+				],
+				location: {
+					href: "https://www.neaq.org/visit/simons-theatre",
+					text: "Simons Theater",
+				},
+				title: "Closing Announcements",
+			},
+			{
+				at: "6:00pm",
+				description: [
+					"We'll arrange suggested dinner and casual social gathering locations for attendees.",
+				],
+				title: "Casual Mid-Conference Suggestions",
+			},
+		],
+		title: "Thursday, September 18th",
+	},
+	{
+		activities: [
+			{
+				at: "7:00am",
+				description: [
+					"Join organizers, volunteers, and attendees for a free joyful jog around the Boston harbor.",
+					"We'll meet at the New England Aquarium and run in a 5k loop at a comfortably light pace.",
+				],
+				location: {
+					href: "https://www.neaq.org/visit",
+					text: "New England Aquarium",
+				},
+				title: "Morning Fun Run",
+			},
+			{
+				at: "8:45am",
+				description: [
+					"Come over to the venue, collect your badge, and network with fellow attendees.",
+				],
+				location: {
+					href: "https://www.neaq.org/visit/simons-theatre",
+					text: "Simons Theater",
+				},
+				title: "Doors Open",
+			},
+			{
+				at: "10:00am",
+				description: ["Full-length and lightning talks from our speakers."],
+				location: {
+					href: "https://www.neaq.org/visit/simons-theatre",
+					text: "Simons Theater",
+				},
+				title: "Talks",
+			},
+			{
+				at: "12:30pm",
+				description: [
+					"Head over to the nearby Faneuil Hall Marketplace for lunch.",
+					"We'll have volunteers available to bring groups to and from popular food establishments.",
+				],
+				location: {
+					href: "https://faneuilhallmarketplace.com",
+					text: "Faneuil Hall Marketplace",
+				},
+				title: "Lunch",
+			},
+			{
+				at: "2:15pm",
+				description: ["Full-length and lightning talks from our speakers."],
+				location: {
+					href: "https://www.neaq.org/visit/simons-theatre",
+					text: "Simons Theater",
+				},
+				title: "Talks",
+			},
+			{
+				at: "3:45pm",
+				description: [
+					"What a day! Let's take a breather to have a snack and chat.",
+				],
+				location: {
+					href: "https://www.neaq.org/visit/simons-theatre",
+					text: "Simons Theater",
+				},
+				title: "Afternoon Snack",
+			},
+			{
+				at: "4:00pm",
+				description: ["Full-length and lightning talks from our speakers."],
+				location: {
+					href: "https://www.neaq.org/visit/simons-theatre",
+					text: "Simons Theater",
+				},
+				title: "Talks",
+			},
+			{
+				at: "4:45pm",
+				description: [
+					"Final pieces of information on upcoming events, raffle giveaways, and appreciation notes to all of the lovely people who attended.",
+				],
+				location: {
+					href: "https://www.neaq.org/visit/simons-theatre",
+					text: "Simons Theater",
+				},
+				title: "Closing Announcements",
+			},
+			{
+				at: "6:00pm",
+				description: [
+					"We'll arrange suggested dinner and casual social gathering locations for attendees.",
+				],
+				title: "Suggested Dinner Spots",
+			},
+			{
+				at: "7:30pm",
+				description: [
+					"After dinner, bring your badge for entry and hang out with the organizers, speakers, and fellow attendees in our mixer.",
+					"Expect locally prepared hors d'œuvres and a craft lemonade stand.",
+				],
+				location: {
+					href: "https://www.howlatthemoon.com/boston",
+					text: "Howl at the Moon Boston",
+				},
+				title: "Post-Conference Hangout",
+			},
+		],
+		title: "Friday, September 19th",
+	},
+];

--- a/src/pages/faqs.astro
+++ b/src/pages/faqs.astro
@@ -197,7 +197,6 @@ Note that talk tickets _do not_ include:
 	details {
 		font-size: var(--fontSizeBody);
 		font-weight: var(--fontWeightLight);
-		line-height: var(--lineHeightBody);
 		margin-bottom: 1.5rem;
 		text-align: left;
 		width: 100%;

--- a/src/pages/schedule.astro
+++ b/src/pages/schedule.astro
@@ -52,7 +52,7 @@ const description =
 
 		{
 			days.map(({ activities, title }) => (
-				<section>
+				<section class="schedule-section">
 					<Heading
 						class="schedule-heading"
 						id={title.split(/\W+/)[0].toLowerCase()}
@@ -91,12 +91,16 @@ const description =
 		margin: auto;
 	}
 
+	.schedule-section {
+		margin-bottom: 3.5rem;
+	}
+
 	.schedule-heading {
 		font-family: var(--fontFamilyHeading);
 		font-size: var(--fontSizeLarge);
 		font-weight: var(--fontWeightBold);
 		line-height: 1;
-		margin: 7rem 0 3.5rem;
+		margin: 3.5rem 0;
 		text-align: center;
 	}
 </style>

--- a/src/pages/schedule.astro
+++ b/src/pages/schedule.astro
@@ -1,0 +1,102 @@
+---
+import BodyText from "~/components/BodyText.astro";
+import CommonContent from "~/components/CommonContent.astro";
+import Hero from "~/components/hero/Hero.astro";
+import HeroContentsStandard from "~/components/hero/HeroContentsStandard.astro";
+import { days } from "~/data/schedule";
+import Registration from "~/components/Registration.astro";
+import PageLayout from "~/layouts/PageLayout.astro";
+import Heading from "~/components/Heading.astro";
+import ScheduledActivity from "~/components/ScheduledActivity.astro";
+
+const description =
+	"Important dates leading up to SquiggleConf 2025 and events during the conference itself.";
+---
+
+<PageLayout description={description} title="Schedule">
+	<Hero>
+		<HeroContentsStandard heading="Schedule" squiggly="wide">
+			{description}
+		</HeroContentsStandard>
+	</Hero>
+
+	<CommonContent heading="CFP">
+		<BodyText>
+			The SquiggleConf CFP will be open through May 23rd. See <a href="/cfp"
+				>CFP</a
+			> for more details.
+		</BodyText>
+	</CommonContent>
+
+	<CommonContent heading="Tickets">
+		<ol class="tickets-list">
+			<li>
+				$350 Extra early bird tickets were be available in limited quantities
+				through March 30th. They are now sold out.
+			</li>
+			<li>
+				$450 Early bird tickets will be available in limited quantities through
+				June 30th.
+			</li>
+			<li>
+				$550 General admission tickets will be available until the morning of
+				the conference.
+			</li>
+		</ol>
+	</CommonContent>
+
+	<CommonContent heading="The Conference">
+		<BodyText class="time-zone-note"
+			>All times are in EDT, local to Boston.</BodyText
+		>
+
+		{
+			days.map(({ activities, title }) => (
+				<section>
+					<Heading
+						class="schedule-heading"
+						id={title.split(/\W+/)[0].toLowerCase()}
+						level="h2"
+						link
+					>
+						{title}
+					</Heading>
+
+					{activities.map((activity) => (
+						<ScheduledActivity
+							at={activity.at}
+							description={activity.description}
+							location={activity.location}
+							title={activity.title}
+						/>
+					))}
+				</section>
+			))
+		}
+	</CommonContent>
+
+	<Registration />
+</PageLayout>
+
+<style>
+	.tickets-list {
+		font-size: var(--fontSizeSmall);
+		font-weight: var(--fontWeightMedium);
+		display: flex;
+		gap: 1rem;
+		flex-direction: column;
+	}
+
+	.time-zone-note {
+		margin: auto;
+	}
+
+	.schedule-heading {
+		font-family: var(--fontFamilyHeading);
+		font-size: var(--fontSizeLarge);
+		font-weight: var(--fontWeightBold);
+		line-height: 1;
+		margin: 7rem 0 3.5rem;
+		text-align: center;
+	}
+</style>

--- a/src/pages/schedule.astro
+++ b/src/pages/schedule.astro
@@ -39,8 +39,8 @@ const description =
 				June 30th.
 			</li>
 			<li>
-				$550 General admission tickets will be available until the morning of
-				September 18th.
+				$550 General tickets will be available until the morning of September
+				18th.
 			</li>
 		</ol>
 	</CommonContent>

--- a/src/pages/schedule.astro
+++ b/src/pages/schedule.astro
@@ -46,9 +46,9 @@ const description =
 	</CommonContent>
 
 	<CommonContent heading="The Conference">
-		<BodyText class="time-zone-note"
-			>All times are in EDT, local to Boston.</BodyText
-		>
+		<BodyText class="time-zone-note">
+			All times are in EDT, local to Boston.
+		</BodyText>
 
 		{
 			days.map(({ activities, title }) => (

--- a/src/pages/schedule.astro
+++ b/src/pages/schedule.astro
@@ -31,16 +31,16 @@ const description =
 	<CommonContent heading="Tickets">
 		<ol class="tickets-list">
 			<li>
-				$350 Extra early bird tickets were be available in limited quantities
-				through March 30th. They are now sold out.
+				$300 Super early bird tickets were available in limited quantities
+				through March 2nd. They are now sold out.
 			</li>
 			<li>
-				$450 Early bird tickets will be available in limited quantities through
+				$350 Early bird tickets will be available in limited quantities through
 				June 30th.
 			</li>
 			<li>
 				$550 General admission tickets will be available until the morning of
-				the conference.
+				September 18th.
 			</li>
 		</ol>
 	</CommonContent>


### PR DESCRIPTION
## Overview

Adds a `/schedule` page with the grid/table view of scheduled activities copied from 2024.