### PR TITLE
feat: add Speaker Guide article

### DIFF
--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="astro/client" />
+/// <reference path="content.d.ts" />

--- a/cspell.json
+++ b/cspell.json
@@ -27,6 +27,7 @@
 		"Harborside",
 		"Harborwalk",
 		"Inngest",
+		"Joia",
 		"josefin",
 		"konami",
 		"Mariah",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
 		"@konami-emoji-blast/astro": "^0.1.1",
 		"astro": "5.3.0",
 		"konami-emoji-blast": "^0.5.9",
-		"sharp": "^0.33.5"
+		"sharp": "^0.33.5",
+		"temporal-polyfill": "^0.3.0"
 	},
 	"devDependencies": {
 		"@eslint-community/eslint-plugin-eslint-comments": "^4.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       sharp:
         specifier: ^0.33.5
         version: 0.33.5
+      temporal-polyfill:
+        specifier: ^0.3.0
+        version: 0.3.0
     devDependencies:
       '@eslint-community/eslint-plugin-eslint-comments':
         specifier: ^4.4.1
@@ -3055,6 +3058,12 @@ packages:
   tar@7.4.3:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
     engines: {node: '>=18'}
+
+  temporal-polyfill@0.3.0:
+    resolution: {integrity: sha512-qNsTkX9K8hi+FHDfHmf22e/OGuXmfBm9RqNismxBrnSmZVJKegQ+HYYXT+R7Ha8F/YSm2Y34vmzD4cxMu2u95g==}
+
+  temporal-spec@0.3.0:
+    resolution: {integrity: sha512-n+noVpIqz4hYgFSMOSiINNOUOMFtV5cZQNCmmszA6GiVFVRt3G7AqVyhXjhCSmowvQn+NsGn+jMDMKJYHd3bSQ==}
 
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
@@ -6966,6 +6975,12 @@ snapshots:
       minizlib: 3.0.1
       mkdirp: 3.0.1
       yallist: 5.0.0
+
+  temporal-polyfill@0.3.0:
+    dependencies:
+      temporal-spec: 0.3.0
+
+  temporal-spec@0.3.0: {}
 
   thenify-all@1.6.0:
     dependencies:

--- a/src/components/ArticlesList.astro
+++ b/src/components/ArticlesList.astro
@@ -31,8 +31,11 @@ interface Props {
 
 <style>
 	ul {
-		padding: 5rem 0;
+		display: flex;
+		flex-direction: column;
+		gap: 2rem;
 		list-style-type: none;
+		padding: 5rem 0;
 	}
 
 	h2 {

--- a/src/components/BodyList.astro
+++ b/src/components/BodyList.astro
@@ -15,4 +15,9 @@ const { as: As, class: className, ...rest } = Astro.props;
 		flex-direction: column;
 		gap: 0.75rem;
 	}
+
+	.body-list :global(ul) {
+		padding-inline-start: 1rem;
+		font-size: 90%;
+	}
 </style>

--- a/src/components/CommonContent.astro
+++ b/src/components/CommonContent.astro
@@ -1,4 +1,5 @@
 ---
+import { slugify } from "~/utils/id";
 import ContentArea from "./ContentArea.astro";
 import Heading from "./Heading.astro";
 
@@ -12,7 +13,9 @@ const { class: className, level = "h2", ...rest } = Astro.props;
 ---
 
 <ContentArea class:list={["common-content", className]} width="thin" {...rest}>
-	<Heading level={level}>{Astro.props.heading}</Heading>
+	<Heading id={slugify(Astro.props.heading)} level={level}>
+		{Astro.props.heading}
+	</Heading>
 	<slot />
 </ContentArea>
 

--- a/src/components/FAQSection.astro
+++ b/src/components/FAQSection.astro
@@ -1,0 +1,99 @@
+---
+import { markdown } from "@astropub/md";
+import { Image } from "astro:assets";
+
+import dropdown from "~/assets/glyphs/dropdown.svg";
+
+import Heading from "./Heading.astro";
+
+export interface Props {
+	pairs: [string, string][];
+	title: string;
+}
+
+const pairs = await Promise.all(
+	Astro.props.pairs.map(async ([question, answer]) => {
+		const parsedAnswer = await markdown(answer);
+		return [question, parsedAnswer];
+	}),
+);
+---
+
+<div>
+	<Heading class="h3" level="h3">
+		{Astro.props.title}
+	</Heading>
+	{
+		pairs.map(([question, answer]) => (
+			<details>
+				<summary>
+					<span>{question}</span>
+					<Image alt="" src={dropdown} />
+				</summary>
+				<div class="faq-answer">{answer}</div>
+			</details>
+		))
+	}
+</div>
+
+<style>
+	.h3 {
+		font-size: var(--fontSizeMedium);
+		font-weight: var(--fontWeightMedium);
+	}
+
+	html.dark summary img {
+		filter: invert();
+	}
+
+	html:not(.dark) summary img {
+		filter: hue-rotate(180deg);
+	}
+
+	details {
+		font-size: var(--fontSizeBody);
+		font-weight: var(--fontWeightLight);
+		margin-bottom: 1.5rem;
+		text-align: left;
+		width: 100%;
+	}
+
+	summary {
+		cursor: pointer;
+		display: flex;
+		font-weight: var(--fontWeightMedium);
+		justify-content: space-between;
+		list-style: none;
+		margin-top: 1.75rem;
+		position: relative;
+	}
+
+	details[open] summary {
+		margin-bottom: 1rem;
+	}
+
+	details summary img {
+		transition: var(--transitionMedium) transform;
+		user-select: none;
+	}
+
+	details[open] summary img {
+		transform: rotate(180deg);
+	}
+
+	@media (min-width: 819px) {
+		.faq-answer {
+			padding-right: 2rem;
+		}
+	}
+</style>
+
+<style is:global>
+	details ul {
+		margin: 0.75rem 0 0.75rem 1rem;
+	}
+
+	details li {
+		list-style: initial;
+	}
+</style>

--- a/src/components/FAQSection.astro
+++ b/src/components/FAQSection.astro
@@ -90,7 +90,7 @@ const pairs = await Promise.all(
 
 	@media (min-width: 819px) {
 		.faq-answer {
-			padding-right: 2rem;
+			padding: 0 2rem 0 2.5rem;
 		}
 	}
 </style>

--- a/src/components/FAQSection.astro
+++ b/src/components/FAQSection.astro
@@ -27,8 +27,8 @@ const pairs = await Promise.all(
 		pairs.map(([question, answer]) => (
 			<details>
 				<summary>
-					<span>{question}</span>
 					<Image alt="" src={dropdown} />
+					<span>{question}</span>
 				</summary>
 				<div class="faq-answer">{answer}</div>
 			</details>
@@ -63,10 +63,12 @@ const pairs = await Promise.all(
 	}
 
 	summary {
+		align-items: center;
 		cursor: pointer;
 		display: flex;
 		font-weight: var(--fontWeightSemibold);
-		justify-content: space-between;
+		justify-content: flex-start;
+		gap: 0.5rem;
 		list-style: none;
 		margin-top: 1.75rem;
 		position: relative;
@@ -79,6 +81,7 @@ const pairs = await Promise.all(
 	details summary img {
 		transition: var(--transitionMedium) transform;
 		user-select: none;
+		height: 0.75rem;
 	}
 
 	details[open] summary img {

--- a/src/components/FAQSection.astro
+++ b/src/components/FAQSection.astro
@@ -53,15 +53,19 @@ const pairs = await Promise.all(
 	details {
 		font-size: var(--fontSizeBody);
 		font-weight: var(--fontWeightLight);
-		margin-bottom: 1.5rem;
+		margin-bottom: 2rem;
 		text-align: left;
 		width: 100%;
+	}
+
+	details[open] {
+		margin-bottom: 2.5rem;
 	}
 
 	summary {
 		cursor: pointer;
 		display: flex;
-		font-weight: var(--fontWeightMedium);
+		font-weight: var(--fontWeightSemibold);
 		justify-content: space-between;
 		list-style: none;
 		margin-top: 1.75rem;

--- a/src/components/FAQSections.astro
+++ b/src/components/FAQSections.astro
@@ -1,0 +1,26 @@
+---
+import FAQSection, { Props as FAQSectionProps } from "./FAQSection.astro";
+
+interface Props {
+	sections: FAQSectionProps[];
+}
+---
+
+<div class="faq-sections">
+	{
+		Astro.props.sections.map(({ title, pairs: section }) => (
+			<FAQSection pairs={section} title={title} />
+		))
+	}
+</div>
+
+<style>
+	.faq-sections {
+		display: flex;
+		flex-direction: column;
+		gap: 3rem;
+		margin-top: 5rem;
+		padding-bottom: 3.5rem;
+		width: 100%;
+	}
+</style>

--- a/src/components/ScheduledActivities.astro
+++ b/src/components/ScheduledActivities.astro
@@ -24,6 +24,7 @@ interface Props {
 				{activities.map((activity) => (
 					<ScheduledActivity
 						at={activity.at}
+						badge={activity.badge}
 						description={activity.description}
 						location={activity.location}
 						title={activity.title}

--- a/src/components/ScheduledActivities.astro
+++ b/src/components/ScheduledActivities.astro
@@ -1,0 +1,46 @@
+---
+import { ScheduleDay } from "~/data/schedule";
+import Heading from "~/components/Heading.astro";
+import ScheduledActivity from "~/components/ScheduledActivity.astro";
+
+interface Props {
+	days: ScheduleDay[];
+}
+---
+
+<div>
+	{
+		Astro.props.days.map(({ activities, title }) => (
+			<section class="schedule-section">
+				<Heading
+					class="schedule-heading"
+					id={title.split(/\W+/)[0].toLowerCase()}
+					level="h2"
+					link
+				>
+					{title}
+				</Heading>
+
+				{activities.map((activity) => (
+					<ScheduledActivity
+						at={activity.at}
+						description={activity.description}
+						location={activity.location}
+						title={activity.title}
+					/>
+				))}
+			</section>
+		))
+	}
+</div>
+
+<style>
+	.schedule-heading {
+		font-family: var(--fontFamilyHeading);
+		font-size: var(--fontSizeLarge);
+		font-weight: var(--fontWeightBold);
+		line-height: 1;
+		margin: 3.5rem 0;
+		text-align: center;
+	}
+</style>

--- a/src/components/ScheduledActivity.astro
+++ b/src/components/ScheduledActivity.astro
@@ -7,6 +7,7 @@ import Heading from "./Heading.astro";
 
 interface Props {
 	at?: string;
+	badge?: string;
 	description?: string[];
 	id?: string;
 	location?: ActivityLocation;
@@ -17,6 +18,7 @@ interface Props {
 
 const {
 	at,
+	badge,
 	class: className,
 	description = [],
 	id,
@@ -38,6 +40,7 @@ const descriptionLines = await Promise.all(
 >
 	<Heading level={level} class="activity-title">
 		{title}
+		{badge && <div class="activity-badge">{badge}</div>}
 	</Heading>
 	<div class="activity-locators">
 		<div class="activity-time">{at ?? "Time TBA"}</div>
@@ -69,14 +72,24 @@ const descriptionLines = await Promise.all(
 	}
 
 	.activity-title {
+		align-items: center;
+		display: flex;
 		font-family: var(--fontFamilyLogo);
 		font-size: var(--fontSizeMedium);
 		font-weight: var(--fontWeightLogo);
+		justify-content: space-between;
 		text-decoration: none;
 	}
 
-	.activity-title-inner {
-		display: inline;
+	.activity-badge {
+		border-radius: 4px;
+		border: 1px solid var(--colorAccentMedium);
+		color: var(--colorAccent);
+		font-size: var(--fontSizeSmaller);
+		font-weight: var(--fontWeightLight);
+		padding: 0.5rem 0.7rem;
+		text-align: center;
+		user-select: none;
 	}
 
 	.activity-locators {
@@ -118,7 +131,14 @@ const descriptionLines = await Promise.all(
 		}
 
 		.activity-title {
+			display: block;
 			grid-area: 1 / 2 / 2 / 3;
+		}
+
+		.activity-badge {
+			float: right;
+			padding: 0.5rem 0.75rem;
+			margin: -0.25rem 0;
 		}
 
 		.activity-locators {

--- a/src/components/ScheduledActivity.astro
+++ b/src/components/ScheduledActivity.astro
@@ -4,7 +4,6 @@ import { markdown } from "@astropub/md";
 import { ActivityLocation } from "~/data/schedule";
 
 import Heading from "./Heading.astro";
-import Arrow from "./Arrow.astro";
 
 interface Props {
 	at?: string;

--- a/src/components/ScheduledActivity.astro
+++ b/src/components/ScheduledActivity.astro
@@ -74,10 +74,10 @@ const descriptionLines = await Promise.all(
 	.activity-title {
 		align-items: center;
 		display: flex;
+		gap: 1rem;
 		font-family: var(--fontFamilyLogo);
 		font-size: var(--fontSizeMedium);
 		font-weight: var(--fontWeightLogo);
-		justify-content: space-between;
 		text-decoration: none;
 	}
 
@@ -85,6 +85,7 @@ const descriptionLines = await Promise.all(
 		border-radius: 4px;
 		border: 1px solid var(--colorAccentMedium);
 		color: var(--colorAccent);
+		display: inline-block;
 		font-size: var(--fontSizeSmaller);
 		font-weight: var(--fontWeightLight);
 		padding: 0.5rem 0.7rem;
@@ -131,14 +132,12 @@ const descriptionLines = await Promise.all(
 		}
 
 		.activity-title {
-			display: block;
 			grid-area: 1 / 2 / 2 / 3;
 		}
 
 		.activity-badge {
-			float: right;
 			padding: 0.5rem 0.75rem;
-			margin: -0.25rem 0;
+			margin: -0.35rem 0 -0.2rem;
 		}
 
 		.activity-locators {

--- a/src/components/ScheduledActivity.astro
+++ b/src/components/ScheduledActivity.astro
@@ -78,17 +78,18 @@ const descriptionLines = await Promise.all(
 		font-family: var(--fontFamilyLogo);
 		font-size: var(--fontSizeMedium);
 		font-weight: var(--fontWeightLogo);
+		justify-content: space-between;
 		text-decoration: none;
 	}
 
 	.activity-badge {
 		border-radius: 4px;
-		border: 1px solid var(--colorAccentMedium);
-		color: var(--colorAccent);
+		background: var(--colorAccentMedium);
+		color: var(--colorBlackIsh);
 		display: inline-block;
-		font-size: var(--fontSizeSmaller);
-		font-weight: var(--fontWeightLight);
-		padding: 0.5rem 0.7rem;
+		font-size: var(--fontSizeSmallest);
+		font-weight: var(--fontWeightBold);
+		padding: 0.35rem 0.5rem;
 		text-align: center;
 		user-select: none;
 	}
@@ -133,11 +134,12 @@ const descriptionLines = await Promise.all(
 
 		.activity-title {
 			grid-area: 1 / 2 / 2 / 3;
+			justify-content: flex-start;
 		}
 
 		.activity-badge {
-			padding: 0.5rem 0.75rem;
-			margin: -0.35rem 0 -0.2rem;
+			padding: 0.35rem 0.5rem;
+			margin: -0.5rem 0 -0.35rem;
 		}
 
 		.activity-locators {

--- a/src/data/links.ts
+++ b/src/data/links.ts
@@ -4,6 +4,7 @@ export const links = {
 	cfpQuestionsDiscord:
 		"https://discord.com/channels/1181983343387099207/1244808425762848938",
 	cfpQuestionsEmail: "mailto:cfp@squiggleconf.com",
+	discord: "https://discord.squiggleconf.com",
 	michiganTypeScript: "https://youtube.com/@MichiganTypeScript",
 	shop: "https://shop.squiggle.tools",
 	tickets: "https://buytickets.at/squiggleconf/1488622",

--- a/src/data/public.ts
+++ b/src/data/public.ts
@@ -1,0 +1,167 @@
+import { mergeScheduleWithPublic, ScheduleDay } from "./schedule.js";
+
+export const publicSchedule: ScheduleDay[] = mergeScheduleWithPublic([
+	{
+		activities: [
+			{
+				at: "8:45am",
+				description: [
+					"Come over to the venue, collect your badge, and network with fellow attendees.",
+				],
+				location: {
+					href: "https://www.neaq.org/visit/simons-theatre",
+					text: "Simons Theater",
+				},
+				title: "Doors Open",
+			},
+			{
+				at: "10:00am",
+				description: ["Full-length and lightning talks from our speakers."],
+				location: {
+					href: "https://www.neaq.org/visit/simons-theatre",
+					text: "Simons Theater",
+				},
+				title: "Talks",
+			},
+			{
+				at: "12:30pm",
+				description: [
+					"Head over to the nearby Faneuil Hall Marketplace for lunch.",
+					"We'll have volunteers available to bring groups to and from popular food establishments.",
+				],
+				location: {
+					href: "https://faneuilhallmarketplace.com",
+					text: "Faneuil Hall Marketplace",
+				},
+				title: "Lunch",
+			},
+			{
+				at: "2:15pm",
+				description: ["Full-length and lightning talks from our speakers."],
+				location: {
+					href: "https://www.neaq.org/visit/simons-theatre",
+					text: "Simons Theater",
+				},
+				title: "Talks",
+			},
+			{
+				at: "3:45pm",
+				description: [
+					"What a day! Let's take a breather to have a snack and chat.",
+				],
+				location: {
+					href: "https://www.neaq.org/visit/simons-theatre",
+					text: "Simons Theater",
+				},
+				title: "Afternoon Snack",
+			},
+			{
+				at: "4:00pm",
+				description: ["Full-length and lightning talks from our speakers."],
+				location: {
+					href: "https://www.neaq.org/visit/simons-theatre",
+					text: "Simons Theater",
+				},
+				title: "Talks",
+			},
+			{
+				at: "4:45pm",
+				description: [
+					"Final pieces of information on upcoming events, raffle giveaways, and appreciation notes to all of the lovely people who attended.",
+				],
+				location: {
+					href: "https://www.neaq.org/visit/simons-theatre",
+					text: "Simons Theater",
+				},
+				title: "Closing Announcements",
+			},
+			{
+				at: "5:00pm",
+				description: [
+					"Split up into small groups and race to take pictures of historic Boston landmarks as a team.",
+					"We'll provide a list of locations and a map to help you navigate at the end of the closing announcements.",
+					"Prizes will include SquiggleConf swag and free tickets to next year's conference.",
+				],
+				title: "Photo Challenge",
+			},
+		],
+		title: "Thursday, September 18th",
+	},
+	{
+		activities: [
+			{
+				at: "8:45am",
+				description: [
+					"Come over to the venue, collect your badge, and network with fellow attendees.",
+				],
+				location: {
+					href: "https://www.neaq.org/visit/simons-theatre",
+					text: "Simons Theater",
+				},
+				title: "Doors Open",
+			},
+			{
+				at: "10:00am",
+				description: ["Full-length and lightning talks from our speakers."],
+				location: {
+					href: "https://www.neaq.org/visit/simons-theatre",
+					text: "Simons Theater",
+				},
+				title: "Talks",
+			},
+			{
+				at: "12:30pm",
+				description: [
+					"Head over to the nearby Faneuil Hall Marketplace for lunch.",
+					"We'll have volunteers available to bring groups to and from popular food establishments.",
+				],
+				location: {
+					href: "https://faneuilhallmarketplace.com",
+					text: "Faneuil Hall Marketplace",
+				},
+				title: "Lunch",
+			},
+			{
+				at: "2:15pm",
+				description: ["Full-length and lightning talks from our speakers."],
+				location: {
+					href: "https://www.neaq.org/visit/simons-theatre",
+					text: "Simons Theater",
+				},
+				title: "Talks",
+			},
+			{
+				at: "3:45pm",
+				description: [
+					"What a day! Let's take a breather to have a snack and chat.",
+				],
+				location: {
+					href: "https://www.neaq.org/visit/simons-theatre",
+					text: "Simons Theater",
+				},
+				title: "Afternoon Snack",
+			},
+			{
+				at: "4:00pm",
+				description: ["Full-length and lightning talks from our speakers."],
+				location: {
+					href: "https://www.neaq.org/visit/simons-theatre",
+					text: "Simons Theater",
+				},
+				title: "Talks",
+			},
+			{
+				at: "4:45pm",
+				description: [
+					"Final pieces of information on upcoming events, raffle giveaways, and appreciation notes to all of the lovely people who attended.",
+				],
+				location: {
+					href: "https://www.neaq.org/visit/simons-theatre",
+					text: "Simons Theater",
+				},
+				title: "Closing Announcements",
+			},
+		],
+		title: "Friday, September 19th",
+	},
+]);

--- a/src/data/schedule.ts
+++ b/src/data/schedule.ts
@@ -1,12 +1,17 @@
+import { Temporal } from "temporal-polyfill";
+
+import { parseTimeToNumber } from "./time";
+
 export interface ActivityBetweenData extends ActivityDataWithinBase {
 	title: string;
 	type: "between";
 }
 
 export interface ActivityData {
-	at?: string;
+	at: string;
 	description: string[];
 	location?: ActivityLocation;
+	privacy?: Partial<Record<ActivityPrivacy, boolean>>;
 	title: string;
 	within?: ActivityDataWithin[];
 }
@@ -22,6 +27,8 @@ export interface ActivityLocation {
 	text: string;
 }
 
+export type ActivityPrivacy = "speakers" | "sponsors";
+
 export interface ActivitySessionData extends ActivityDataWithinBase {
 	session: string;
 	type: "session";
@@ -32,16 +39,16 @@ export interface ScheduleDay {
 	title: string;
 }
 
-export const days: ScheduleDay[] = [
+export const sharedSchedule: ScheduleDay[] = [
 	{
 		activities: [
 			{
-				at: "Afternoon",
+				at: "4:00pm",
 				description: [
 					"We will arrange a volunteering event with a local non-profit the afternoon before the conference.",
 					`This event will free and open to any attendee who can code in at least HTML.`,
 				],
-				title: " Volunteering Event",
+				title: "Volunteering Event",
 			},
 		],
 		title: "Wednesday, September 17th",
@@ -61,91 +68,10 @@ export const days: ScheduleDay[] = [
 				title: "Morning Fun Run",
 			},
 			{
-				at: "8:45am",
-				description: [
-					"Come over to the venue, collect your badge, and network with fellow attendees.",
-				],
-				location: {
-					href: "https://www.neaq.org/visit/simons-theatre",
-					text: "Simons Theater",
-				},
-				title: "Doors Open",
-			},
-			{
-				at: "10:00am",
-				description: ["Full-length and lightning talks from our speakers."],
-				location: {
-					href: "https://www.neaq.org/visit/simons-theatre",
-					text: "Simons Theater",
-				},
-				title: "Talks",
-			},
-			{
-				at: "12:30pm",
-				description: [
-					"Head over to the nearby Faneuil Hall Marketplace for lunch.",
-					"We'll have volunteers available to bring groups to and from popular food establishments.",
-				],
-				location: {
-					href: "https://faneuilhallmarketplace.com",
-					text: "Faneuil Hall Marketplace",
-				},
-				title: "Lunch",
-			},
-			{
-				at: "2:15pm",
-				description: ["Full-length and lightning talks from our speakers."],
-				location: {
-					href: "https://www.neaq.org/visit/simons-theatre",
-					text: "Simons Theater",
-				},
-				title: "Talks",
-			},
-			{
-				at: "3:45pm",
-				description: [
-					"What a day! Let's take a breather to have a snack and chat.",
-				],
-				location: {
-					href: "https://www.neaq.org/visit/simons-theatre",
-					text: "Simons Theater",
-				},
-				title: "Afternoon Snack",
-			},
-			{
-				at: "4:00pm",
-				description: ["Full-length and lightning talks from our speakers."],
-				location: {
-					href: "https://www.neaq.org/visit/simons-theatre",
-					text: "Simons Theater",
-				},
-				title: "Talks",
-			},
-			{
-				at: "4:45pm",
-				description: [
-					"Final pieces of information on upcoming events, raffle giveaways, and appreciation notes to all of the lovely people who attended.",
-				],
-				location: {
-					href: "https://www.neaq.org/visit/simons-theatre",
-					text: "Simons Theater",
-				},
-				title: "Closing Announcements",
-			},
-			{
-				at: "5:00pm",
-				description: [
-					"Split up into small groups and race to take pictures of historic Boston landmarks as a team.",
-					"We'll provide a list of locations and a map to help you navigate at the end of the closing announcements.",
-					"Prizes will include SquiggleConf swag and free tickets to next year's conference.",
-				],
-				title: "Photo Challenge",
-			},
-			{
 				// todo: switch to string[] for less prominent &
 				at: "6:00pm & 7:00pm",
 				description: [
-					"We'll arrange suggested dinner and casual social gathering locations for attendees.",
+					"We'll arrange suggested dinner and casual social gathering locations for attendees, speakers, and sponsors.",
 				],
 				title: "Suggested Dinner Locations",
 			},
@@ -167,97 +93,59 @@ export const days: ScheduleDay[] = [
 				title: "Morning Fun Run",
 			},
 			{
-				at: "8:45am",
-				description: [
-					"Come over to the venue, collect your badge, and network with fellow attendees.",
-				],
-				location: {
-					href: "https://www.neaq.org/visit/simons-theatre",
-					text: "Simons Theater",
-				},
-				title: "Doors Open",
-			},
-			{
-				at: "10:00am",
-				description: ["Full-length and lightning talks from our speakers."],
-				location: {
-					href: "https://www.neaq.org/visit/simons-theatre",
-					text: "Simons Theater",
-				},
-				title: "Talks",
-			},
-			{
-				at: "12:30pm",
-				description: [
-					"Head over to the nearby Faneuil Hall Marketplace for lunch.",
-					"We'll have volunteers available to bring groups to and from popular food establishments.",
-				],
-				location: {
-					href: "https://faneuilhallmarketplace.com",
-					text: "Faneuil Hall Marketplace",
-				},
-				title: "Lunch",
-			},
-			{
-				at: "2:15pm",
-				description: ["Full-length and lightning talks from our speakers."],
-				location: {
-					href: "https://www.neaq.org/visit/simons-theatre",
-					text: "Simons Theater",
-				},
-				title: "Talks",
-			},
-			{
-				at: "3:45pm",
-				description: [
-					"What a day! Let's take a breather to have a snack and chat.",
-				],
-				location: {
-					href: "https://www.neaq.org/visit/simons-theatre",
-					text: "Simons Theater",
-				},
-				title: "Afternoon Snack",
-			},
-			{
-				at: "4:00pm",
-				description: ["Full-length and lightning talks from our speakers."],
-				location: {
-					href: "https://www.neaq.org/visit/simons-theatre",
-					text: "Simons Theater",
-				},
-				title: "Talks",
-			},
-			{
-				at: "4:45pm",
-				description: [
-					"Final pieces of information on upcoming events, raffle giveaways, and appreciation notes to all of the lovely people who attended.",
-				],
-				location: {
-					href: "https://www.neaq.org/visit/simons-theatre",
-					text: "Simons Theater",
-				},
-				title: "Closing Announcements",
-			},
-			{
 				at: "6:00pm",
 				description: [
 					"We'll arrange suggested dinner and casual social gathering locations for attendees.",
 				],
 				title: "Suggested Dinner Spots",
 			},
-			{
-				at: "7:30pm",
-				description: [
-					"After dinner, bring your badge for entry and hang out with the organizers, speakers, and fellow attendees in our mixer.",
-					"Expect locally prepared hors d'œuvres and a craft lemonade stand.",
-				],
-				location: {
-					href: "https://www.howlatthemoon.com/boston",
-					text: "Howl at the Moon Boston",
-				},
-				title: "Post-Conference Hangout",
-			},
 		],
 		title: "Friday, September 19th",
 	},
 ];
+
+export function mergeScheduleWithPublic(
+	schedule: ScheduleDay[],
+): ScheduleDay[] {
+	return mergeSchedules(sharedSchedule, schedule);
+}
+
+function mergeActivities(existing: ActivityData[], added: ActivityData[]) {
+	return [...existing, ...added].sort((a, b) =>
+		Temporal.PlainTime.compare(
+			parseTimeToNumber(a.at),
+			parseTimeToNumber(b.at),
+		),
+	);
+}
+
+function mergeSchedules(...schedules: ScheduleDay[][]): ScheduleDay[] {
+	const merged = schedules.reduce<ScheduleDay[]>((accumulator, schedule) => {
+		schedule.forEach((day) => {
+			const existingDay = accumulator.find(
+				(existingDay) => existingDay.title === day.title,
+			);
+
+			if (!existingDay) {
+				accumulator = [...accumulator, day];
+				return;
+			}
+
+			accumulator = accumulator.map((existingDay) =>
+				existingDay.title === day.title
+					? {
+							...existingDay,
+							activities: mergeActivities(
+								existingDay.activities,
+								day.activities,
+							),
+						}
+					: existingDay,
+			);
+		});
+
+		return accumulator;
+	}, []);
+
+	return merged;
+}

--- a/src/data/schedule.ts
+++ b/src/data/schedule.ts
@@ -1,6 +1,6 @@
 import { Temporal } from "temporal-polyfill";
 
-import { parseTimeToNumber } from "./time";
+import { parseTimeToNumber } from "./time.js";
 
 export interface ActivityBetweenData extends ActivityDataWithinBase {
 	title: string;

--- a/src/data/schedule.ts
+++ b/src/data/schedule.ts
@@ -9,6 +9,7 @@ export interface ActivityBetweenData extends ActivityDataWithinBase {
 
 export interface ActivityData {
 	at: string;
+	badge?: string;
 	description: string[];
 	location?: ActivityLocation;
 	privacy?: Partial<Record<ActivityPrivacy, boolean>>;

--- a/src/data/socials.ts
+++ b/src/data/socials.ts
@@ -5,6 +5,7 @@ import linkedin from "../assets/logos/linkedin.svg";
 import mastodon from "../assets/logos/mastodon.svg";
 import twitter from "../assets/logos/twitter.svg";
 import youtube from "../assets/logos/youtube.svg";
+import { links } from "./links.js";
 
 export const socials = [
 	{
@@ -39,7 +40,7 @@ export const socials = [
 	},
 	{
 		alt: "Discord",
-		href: "https://discord.squiggleconf.com",
+		href: links.discord,
 		src: discord,
 	},
 ].sort((a, b) => a.alt.localeCompare(b.alt));

--- a/src/data/speaking.ts
+++ b/src/data/speaking.ts
@@ -1,0 +1,109 @@
+import { mergeScheduleWithPublic, ScheduleDay } from "./schedule.js";
+
+export const speakerSchedule: ScheduleDay[] = mergeScheduleWithPublic([
+	{
+		activities: [
+			{
+				at: "3:00pm",
+				description: [
+					"Check-in for the hotel is at 3:00pm. Call the hotel well in advance if you'd like to request an early check-in.",
+				],
+				location: {
+					href: "https://www.harborsideinnboston.com",
+					text: "Harborside Inn",
+				},
+				title: "Hotel Check-in",
+			},
+			{
+				at: "7:00pm",
+				description: [
+					"Join us for a dinner with the other speakers and sponsors.",
+					"This is a great opportunity to meet your fellow speakers and sponsors, and to get to know each other before the conference.",
+				],
+				location: {
+					href: "https://joiaboston.com",
+					text: "Joia Restaurant & Lounge",
+				},
+				title: "Speaker & Sponsor Dinner",
+			},
+		],
+		title: "Wednesday, September 17th",
+	},
+	{
+		activities: [
+			{
+				at: "8:45am",
+				description: [
+					"Doors open at 8:45am and the conference extends through 5:00pm.",
+					"See [Schedule > Thursday, September 18th](/schedule#thursday) for more details.",
+				],
+				location: {
+					href: "https://www.neaq.org/visit/simons-theatre",
+					text: "Simons Theater",
+				},
+				title: "Day 1",
+			},
+			{
+				at: "5:00pm",
+				description: [
+					"A private event for speakers, sponsors, and makers in the dev tooling community.",
+				],
+				title: "Ice Cream Social",
+			},
+		],
+		title: "Thursday, September 18th",
+	},
+	{
+		activities: [
+			{
+				at: "8:45am",
+				description: [
+					"Doors open at 8:45am and the conference extends through 5:00pm.",
+					"See [Schedule > Friday, September 19th](/schedule#friday) for more details.",
+				],
+				location: {
+					href: "https://www.neaq.org/visit/simons-theatre",
+					text: "Simons Theater",
+				},
+				title: "Day 2",
+			},
+			{
+				at: "7:30pm",
+				description: [
+					"After dinner, bring your badge for entry and hang out with the organizers, speakers, and fellow attendees in our mixer.",
+					"Expect locally prepared hors d'œuvres and a craft lemonade stand.",
+				],
+				location: {
+					href: "https://www.howlatthemoon.com/boston",
+					text: "Howl at the Moon Boston",
+				},
+				title: "Post-Conference Hangout",
+			},
+		],
+		title: "Friday, September 19th",
+	},
+	{
+		activities: [
+			{
+				at: "Morning",
+				description: [
+					"If you're staying at the hotel, you'll need to check out before the speaker event.",
+					"The front desk will be able to hold your luggage for the day.",
+				],
+				location: {
+					href: "https://www.harborsideinnboston.com",
+					text: "Harborside Inn",
+				},
+				title: "Hotel Checkout",
+			},
+			{
+				at: "10:00am",
+				description: [
+					"Speakers and organizers will go on a fun private Boston-themed event together.",
+				],
+				title: "Speaker Event",
+			},
+		],
+		title: "Saturday, September 20th",
+	},
+]);

--- a/src/data/speaking.ts
+++ b/src/data/speaking.ts
@@ -1,5 +1,7 @@
 import { mergeScheduleWithPublic, ScheduleDay } from "./schedule.js";
 
+const badge = "Speaker Activity";
+
 export const speakerSchedule: ScheduleDay[] = mergeScheduleWithPublic([
 	{
 		activities: [
@@ -16,6 +18,7 @@ export const speakerSchedule: ScheduleDay[] = mergeScheduleWithPublic([
 			},
 			{
 				at: "7:00pm",
+				badge,
 				description: [
 					"Join us for a dinner with the other speakers and sponsors.",
 					"This is a great opportunity to meet your fellow speakers and sponsors, and to get to know each other before the conference.",
@@ -45,6 +48,7 @@ export const speakerSchedule: ScheduleDay[] = mergeScheduleWithPublic([
 			},
 			{
 				at: "5:00pm",
+				badge,
 				description: [
 					"A private event for speakers, sponsors, and makers in the dev tooling community.",
 				],
@@ -98,6 +102,7 @@ export const speakerSchedule: ScheduleDay[] = mergeScheduleWithPublic([
 			},
 			{
 				at: "10:00am",
+				badge,
 				description: [
 					"Speakers and organizers will go on a fun private Boston-themed event together.",
 				],

--- a/src/data/time.ts
+++ b/src/data/time.ts
@@ -1,0 +1,22 @@
+import { Temporal } from "temporal-polyfill";
+
+export function parseTimeToNumber(timeStr: string) {
+	const firstTimeMentioned = timeStr.split(" ")[0];
+	const match = /^(\d{1,2}):(\d{2})(am|pm)$/i.exec(firstTimeMentioned);
+	if (!match) {
+		return Temporal.PlainTime.from({ hour: 0, minute: 0 });
+	}
+
+	const [, hourRaw, minuteRaw, period] = match;
+	let hour = parseInt(hourRaw, 10);
+	const minute = parseInt(minuteRaw, 10);
+
+	if (period.toLowerCase() === "pm" && hour !== 12) {
+		hour += 12;
+	} else if (period.toLowerCase() === "am" && hour === 12) {
+		hour = 0;
+	}
+	console.log({ firstTimeMentioned, hour, minute, period });
+
+	return Temporal.PlainTime.from({ hour, minute });
+}

--- a/src/data/time.ts
+++ b/src/data/time.ts
@@ -16,7 +16,6 @@ export function parseTimeToNumber(timeStr: string) {
 	} else if (period.toLowerCase() === "am" && hour === 12) {
 		hour = 0;
 	}
-	console.log({ firstTimeMentioned, hour, minute, period });
 
 	return Temporal.PlainTime.from({ hour, minute });
 }

--- a/src/pages/articles.astro
+++ b/src/pages/articles.astro
@@ -19,6 +19,12 @@ const description =
 		articles={[
 			{
 				description:
+					"All the information you'd need to know as a SquiggleConf 2025 speaker.",
+				slug: "/articles/speaker-guide",
+				title: "Speaker Guide",
+			},
+			{
+				description:
 					"13 different ways you can get a free ticket to SquiggleConf 2025. Free!",
 				slug: "/articles/how-to-attend-squiggleconf-for-free",
 				title: "How to Attend SquiggleConf for Free",

--- a/src/pages/articles/speaker-guide.astro
+++ b/src/pages/articles/speaker-guide.astro
@@ -178,7 +178,7 @@ const title = "Speaker Guide";
 							"Will there be water or other snacks for speakers?",
 							"We'll have small snacks, water, and common medicines available for speakers.",
 						],
-						["Will there be wifi?", "Yes, the venue will have wifi."],
+						["Will there be WiFi?", "Yes, the venue will have WiFi."],
 					],
 					title: "Talks",
 				},

--- a/src/pages/articles/speaker-guide.astro
+++ b/src/pages/articles/speaker-guide.astro
@@ -1,0 +1,194 @@
+---
+import BodyList from "~/components/BodyList.astro";
+import BodyText from "~/components/BodyText.astro";
+import CommonContent from "~/components/CommonContent.astro";
+import ContentArea from "~/components/ContentArea.astro";
+import FAQSections from "~/components/FAQSections.astro";
+import Hero from "~/components/hero/Hero.astro";
+import HeroContentsStandard from "~/components/hero/HeroContentsStandard.astro";
+import ScheduledActivities from "~/components/ScheduledActivities.astro";
+import { links } from "~/data/links";
+import { speakerSchedule } from "~/data/speaking.js";
+import PageLayout from "~/layouts/PageLayout.astro";
+
+const description =
+	"All the information you'd need to know as a SquiggleConf 2025 speaker.";
+
+const title = "Speaker Guide";
+---
+
+<PageLayout description={description} title={title}>
+	<Hero>
+		<HeroContentsStandard heading={title} squiggly="none">
+			{description}
+		</HeroContentsStandard>
+	</Hero>
+
+	<ContentArea width="thin">
+		<BodyText class="body-text-top">
+			This page has the high-level information you need to know as a speaker at
+			SquiggleConf 2025.
+		</BodyText>
+
+		<BodyText>That includes:</BodyText>
+
+		<BodyList as="ul">
+			<li>
+				<a href="#speaker-expectations">Speaker Expectations</a>: what we need
+				from you before and during
+			</li>
+			<li>
+				<a href="#speaker-schedule">Speaker Schedule</a>: the schedule of
+				activities common to all speakers
+			</li>
+			<li>
+				<a href="#talk-guide">Talk Schedule</a>: what will happen around your
+				talk on its day
+			</li>
+			<li>
+				<a href="#faqs">FAQs</a>: all other common questions you might have
+			</li>
+		</BodyList>
+
+		<BodyText>
+			Every speaker will be given access to a private "hotline" channel in the
+			<a href={links.discord}>SquiggleConf Discord</a> with the MCs and organizers.
+			Please reach out to us there if you have any questions.
+		</BodyText>
+	</ContentArea>
+
+	<CommonContent heading="Speaker Expectations">
+		<BodyText> This is what we'll need from you as a speaker: </BodyText>
+
+		<BodyList as="ul">
+			<li>
+				Your information:
+				<ul>
+					<li>Preferred first name and name for announcements</li>
+					<li>Bio: short (2-3 sentences) and full (1-2 paragraphs)</li>
+					<li>Photo: at least 512x512px</li>
+					<li>
+						Links on social media we share (Bluesky, Mastodon, LinkedIn, X,
+						YouTube, etc.)
+					</li>
+					<li>Specifics on any accessibility, dietary, or other needs</li>
+				</ul>
+			</li>
+			<li>Giving a private talk dry run 2 weeks prior to the conference</li>
+			<li>
+				Joining the <a href={links.discord}>SquiggleConf Discord</a> and responding
+				to questions during the conference
+			</li>
+		</BodyList>
+	</CommonContent>
+
+	<CommonContent heading="Speaker Schedule">
+		<BodyText>
+			Speakers are invited to all public conference listed on <a
+				href="/schedule">Schedule</a
+			>. This list also shows the private events you have access to.
+		</BodyText>
+
+		<ScheduledActivities days={speakerSchedule} />
+	</CommonContent>
+
+	<CommonContent heading="Talk Schedule">
+		<BodyText> This is what will happen around your talk on its day. </BodyText>
+
+		<BodyList as="ol">
+			<li>20 minutes prior: we'll have a designated space for you to wait</li>
+			<li>10 minutes prior: an A/V volunteer will place a microphone on you</li>
+			<li>
+				5 minutes prior: you'll walk onto the stage and set your laptop up
+			</li>
+			<li>You'll do a wonderful job on the talk, we believe in you!</li>
+			<li>
+				If your talk is a full-length one, an MC will then walk you to the other
+				side of the stage and run a live Q&A with you
+			</li>
+		</BodyList>
+
+		<BodyText>
+			We'll have a dedicated channel set up for you in Discord where attendees
+			can ask you questions during the conference.
+		</BodyText>
+	</CommonContent>
+
+	<CommonContent heading="FAQs">
+		<BodyText>
+			These are the most common questions we get from speakers. If you have any
+			other questions, please reach out to us in your hotline channel.
+		</BodyText>
+
+		<FAQSections
+			sections={[
+				{
+					pairs: [
+						[
+							"Can I extend my hotel stay?",
+							"Yes, but you'll have to talk with the hotel on your own. Let us know if you need help with that.",
+						],
+						[
+							"Can my +1 stay in my hotel room?",
+							"Of course! They'll also receive a free ticket to the conference. Note that we don't cover other +1 costs such as travel.",
+						],
+						[
+							"How do I get to and from the airport?",
+							"We'll have a volunteer drive you to and from the airport. Please let us know your flight details as soon as you know them; we'll coordinate with you.",
+						],
+						[
+							"How far is the hotel from the venue?",
+							"About a [2 minute walk by foot towards the water](https://www.google.com/maps/dir/Harborside+Inn,+185+State+St,+Boston,+MA+02109/Simons+Theater,+Central+Wharf,+Boston,+MA/@42.3589577,-71.0541134,17z/data=!3m1!4b1!4m14!4m13!1m5!1m1!1s0x89e370864b81aa3b:0x29c5617b4f529e85!2m2!1d-71.0528824!2d42.3592384!1m5!1m1!1s0x89e3708790db7415:0xa9fbb8bf1c5e8e24!2m2!1d-71.0501946!2d42.3587791!3e0?entry=ttu&g_ep=EgoyMDI1MDUwNy4wIKXMDSoASAFQAw%3D%3D).",
+						],
+						[
+							"I have a Visa application, can you help with that?",
+							"Yes, we can write you a letter of invitation to help with your Visa application. Please let us know as soon as possible.",
+						],
+						[
+							"Where can I pick up toiletries nearby?",
+							"There is a [7-Eleven next to the hotel](https://www.google.com/maps/place/7-Eleven/@42.3592344,-71.0531519,21z/data=!3m1!5s0x89e3708d5d9bc1dd:0xa146d9e96b0d5416!4m6!3m5!1s0x89e3715588fa5d0d:0xb512a89a39096040!8m2!3d42.359188!4d-71.05307!16s%2Fg%2F11g232jr3m?entry=ttu&g_ep=EgoyMDI1MDUwNy4wIKXMDSoASAFQAw%3D%3D) and a [Walgreens pharmacy a 10 minute walk away](https://www.google.com/maps/dir/Harborside+Inn,+State+Street,+Boston,+MA/Walgreens,+24+School+St,+Boston,+MA+02108/@42.3583403,-71.0571551,18z/data=!3m2!4b1!5s0x89e3708483c2dfa3:0xb1c2f6e51d82959!4m14!4m13!1m5!1m1!1s0x89e370864b81aa3b:0x29c5617b4f529e85!2m2!1d-71.0528824!2d42.3592384!1m5!1m1!1s0x89e370848161a7e5:0x4e2871dbbea4c936!2m2!1d-71.0589654!2d42.3572756!3e2?entry=ttu&g_ep=EgoyMDI1MDUwNy4wIKXMDSoASAFQAw%3D%3D).",
+						],
+					],
+					title: "Accommodations & Travel",
+				},
+				{
+					pairs: [
+						[
+							"Will I be photographed?",
+							"Yes, we'll have a dedicated event photographer during most of the conference.",
+						],
+						[
+							"Will my talk be recorded?",
+							"Yes, we will edit and release on YouTube after the conference for free.",
+						],
+					],
+					title: "Photos & Videos",
+				},
+				{
+					pairs: [
+						[
+							"Will there be a confidence monitor and/or stage timer?",
+							"Yes. Our provided setup will have a confidence monitor showing both your slide notes and what attendees see, as well as the number of minutes you have left.",
+						],
+						[
+							"Will there be a speaker room?",
+							"The venue does not have one. We can get you a small private space if you need it, or the hotel is a 2 minute walk away.",
+						],
+						[
+							"Will there be water or other snacks for speakers?",
+							"We'll have small snacks, water, and common medicines available for speakers.",
+						],
+						["Will there be wifi?", "Yes, the venue will have wifi."],
+					],
+					title: "Talks",
+				},
+			]}
+		/>
+	</CommonContent>
+</PageLayout>
+
+<style>
+	.body-text-top {
+		margin: 5rem auto 1.5rem;
+	}
+</style>

--- a/src/pages/faqs.astro
+++ b/src/pages/faqs.astro
@@ -1,11 +1,10 @@
 ---
 import { markdown } from "@astropub/md";
-import { Image } from "astro:assets";
 
-import dropdown from "~/assets/glyphs/dropdown.svg";
 import BodyText from "~/components/BodyText.astro";
 import ContentArea from "~/components/ContentArea.astro";
-import Heading from "~/components/Heading.astro";
+import FAQSection from "~/components/FAQSection.astro";
+import FAQSections from "~/components/FAQSections.astro";
 import Hero from "~/components/hero/Hero.astro";
 import HeroContentsStandard from "~/components/hero/HeroContentsStandard.astro";
 import { links } from "~/data/links";
@@ -38,7 +37,7 @@ const faqs: FAQSection[] = [
 		[
 			[
 				"What events are you planning?",
-				await markdown(`
+				`
 See <a href="/schedule">Schedule</a> for a high-level overview of our schedule. Details are partially dependent on corporate sponsorships.
 
 <br />
@@ -52,7 +51,7 @@ SquiggleConf will include:
 <br />
 
 Subscribe to the <a href="/#newsletter">newsletter</a> to be the first to know more!
-				`),
+				`,
 			],
 		],
 	],
@@ -61,9 +60,9 @@ Subscribe to the <a href="/#newsletter">newsletter</a> to be the first to know m
 		[
 			[
 				"How can I ask speakers questions?",
-				await markdown(`Talks have time reserved for live Q&A. Additionally, each session has a channel in Discord where you can ask questions.
+				`Talks have time reserved for live Q&A. Additionally, each session has a channel in Discord where you can ask questions.
 				<br />
-				We'd also encourage you to find them in-person between sessions and start conversations. They're friendly people.`),
+				We'd also encourage you to find them in-person between sessions and start conversations. They're friendly people.`,
 			],
 			[
 				"Will talks be recorded?",
@@ -80,20 +79,15 @@ Subscribe to the <a href="/#newsletter">newsletter</a> to be the first to know m
 		[
 			[
 				"Do you have bulk purchasing and/or group options?",
-				await markdown(
-					`Yes! See the [tickets purchase link](${links.tickets}) for the options.`,
-				),
+				`Yes! See the [tickets purchase link](${links.tickets}) for the options.`,
 			],
 			[
 				"If I can't afford a full ticket, is there a way for me to come?",
-				await markdown(
-					`Yes! See [How to Attend SquiggleConf for Free](/articles/how-to-attend-squiggleconf-for-free).`,
-				),
+				`Yes! See [How to Attend SquiggleConf for Free](/articles/how-to-attend-squiggleconf-for-free).`,
 			],
 			[
 				"What does or doesn't a ticket include?",
-				await markdown(
-					`
+				`
 Your ticket gets you:
 
 - Access to all attendee social events before, during, and after the conference
@@ -106,19 +100,14 @@ Note that talk tickets _do not_ include:
 - Meals, including lunch at <a href="https://faneuilhallmarketplace.com" rel="noreferrer" target="_blank">Faneuil Hall Marketplace</a>
 - Travel to or from the conference
 					`,
-				),
 			],
 			[
 				"What is your refund policy?",
-				await markdown(
-					"Full refunds. If you can't make it, please let us know - we can work with you. <br /> Do not come to SquiggleConf if you have any COVID symptoms.",
-				),
+				"Full refunds. If you can't make it, please let us know - we can work with you. <br /> Do not come to SquiggleConf if you have any COVID symptoms.",
 			],
 			[
 				"Will there be ticket sales at the door?",
-				await markdown(
-					"No. All tickets will be sold online. We also cannot guarantee tickets will be available day-of.",
-				),
+				"No. All tickets will be sold online. We also cannot guarantee tickets will be available day-of.",
 			],
 		],
 	],
@@ -138,36 +127,15 @@ Note that talk tickets _do not_ include:
 			<a href="mailto:questions@squiggleconf.com">questions@squiggleconf.com</a>
 		</BodyText>
 
-		<div class="faqs">
-			{
-				faqs.map(([title, section]) => (
-					<div class="section">
-						<Heading class="h3" level="h3">
-							{title}
-						</Heading>
-						{section.map(([question, answer]) => (
-							<details class="details">
-								<summary>
-									<span>{question}</span>
-									<Image alt="" src={dropdown} />
-								</summary>
-								<div class="answer">{answer}</div>
-							</details>
-						))}
-					</div>
-				))
-			}
-		</div>
+		<FAQSections sections={faqs.map(([title, pairs]) => ({ title, pairs }))} />
 	</ContentArea>
 </PageLayout>
 
 <style>
 	.body-text-top {
-		margin: 5rem auto;
+		margin: 5rem auto 0;
 	}
-</style>
 
-<style>
 	.apply-button {
 		align-self: center;
 		gap: 0.5rem;
@@ -177,79 +145,9 @@ Note that talk tickets _do not_ include:
 	.area {
 		font-weight: var(--fontWeightBold);
 	}
-</style>
 
-<style>
 	.action-button {
 		display: inline-block;
 		margin: 2rem;
-	}
-
-	.faqs {
-		display: flex;
-		flex-direction: column;
-		gap: 3rem;
-		padding-bottom: 3.5rem;
-		width: 100%;
-	}
-
-	.h3 {
-		font-size: var(--fontSizeMedium);
-		font-weight: var(--fontWeightMedium);
-	}
-
-	details {
-		font-size: var(--fontSizeBody);
-		font-weight: var(--fontWeightLight);
-		margin-bottom: 1.5rem;
-		text-align: left;
-		width: 100%;
-	}
-
-	summary {
-		cursor: pointer;
-		display: flex;
-		font-weight: var(--fontWeightMedium);
-		justify-content: space-between;
-		list-style: none;
-		margin-top: 1.75rem;
-		position: relative;
-	}
-
-	details[open] summary {
-		margin-bottom: 1rem;
-	}
-
-	details summary img {
-		transition: var(--transitionMedium) transform;
-		user-select: none;
-	}
-
-	details[open] summary img {
-		transform: rotate(180deg);
-	}
-
-	html.dark summary img {
-		filter: invert();
-	}
-
-	html:not(.dark) summary img {
-		filter: hue-rotate(180deg);
-	}
-
-	@media (min-width: 819px) {
-		.answer {
-			padding-right: 2rem;
-		}
-	}
-</style>
-
-<style is:global>
-	details ul {
-		margin: 0.75rem 0 0.75rem 1rem;
-	}
-
-	details li {
-		list-style: initial;
 	}
 </style>

--- a/src/pages/schedule.astro
+++ b/src/pages/schedule.astro
@@ -3,11 +3,10 @@ import BodyText from "~/components/BodyText.astro";
 import CommonContent from "~/components/CommonContent.astro";
 import Hero from "~/components/hero/Hero.astro";
 import HeroContentsStandard from "~/components/hero/HeroContentsStandard.astro";
-import { days } from "~/data/schedule";
+import { publicSchedule } from "~/data/public";
 import Registration from "~/components/Registration.astro";
 import PageLayout from "~/layouts/PageLayout.astro";
-import Heading from "~/components/Heading.astro";
-import ScheduledActivity from "~/components/ScheduledActivity.astro";
+import ScheduledActivities from "~/components/ScheduledActivities.astro";
 
 const description =
 	"Important dates leading up to SquiggleConf 2025 and events during the conference itself.";
@@ -50,29 +49,7 @@ const description =
 			All times are in EDT, local to Boston.
 		</BodyText>
 
-		{
-			days.map(({ activities, title }) => (
-				<section class="schedule-section">
-					<Heading
-						class="schedule-heading"
-						id={title.split(/\W+/)[0].toLowerCase()}
-						level="h2"
-						link
-					>
-						{title}
-					</Heading>
-
-					{activities.map((activity) => (
-						<ScheduledActivity
-							at={activity.at}
-							description={activity.description}
-							location={activity.location}
-							title={activity.title}
-						/>
-					))}
-				</section>
-			))
-		}
+		<ScheduledActivities days={publicSchedule} />
 	</CommonContent>
 
 	<Registration />
@@ -93,14 +70,5 @@ const description =
 
 	.schedule-section {
 		margin-bottom: 3.5rem;
-	}
-
-	.schedule-heading {
-		font-family: var(--fontFamilyHeading);
-		font-size: var(--fontSizeLarge);
-		font-weight: var(--fontWeightBold);
-		line-height: 1;
-		margin: 3.5rem 0;
-		text-align: center;
 	}
 </style>

--- a/src/utils/id.ts
+++ b/src/utils/id.ts
@@ -1,0 +1,3 @@
+export function slugify(title: string) {
+	return title.toLowerCase().replaceAll(" ", "-");
+}


### PR DESCRIPTION
## Overview

Adds a page under `/articles/speaker-guide` with (copying from its display):

- Speaker Expectations: what we need from you before and during
- Speaker Schedule: the schedule of activities common to all speakers
- Talk Schedule: what will happen around your talk on its day
- FAQs: all other common questions you might have

💖 