### PR TITLE
feat: add Travel FAQs to Articles > Speaker Guide

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -27,6 +27,7 @@
 		"Harborside",
 		"Harborwalk",
 		"Inngest",
+		"jetlag",
 		"Joia",
 		"josefin",
 		"konami",

--- a/src/pages/articles/speaker-guide.astro
+++ b/src/pages/articles/speaker-guide.astro
@@ -182,6 +182,23 @@ const title = "Speaker Guide";
 					],
 					title: "Talks",
 				},
+				{
+					pairs: [
+						[
+							"Can I come a day early to offset jetlag?",
+							"We can have you speak on the second day. We don't have the budget to cover your hotel, but you can always arrange that with the hotel on your own.",
+						],
+						[
+							"Do I need to bring my own laptop?",
+							"No, we'll have a dedicated stage speaker laptop with a clicker. Send us your slides ahead of time.",
+						],
+						[
+							"I'm concerned about border crossing difficulties, what should I do?",
+							"Please reach out to us as soon as possible. We can help you with a letter of invitation, public listing of your name and talk on the website, and other documentation. This has not been an issue for us or companies we've worked with in the past, and we will do everything we can to make sure it does not in the future.",
+						],
+					],
+					title: "Travel",
+				},
 			]}
 		/>
 	</CommonContent>

--- a/src/pages/articles/speaker-guide.astro
+++ b/src/pages/articles/speaker-guide.astro
@@ -186,7 +186,7 @@ const title = "Speaker Guide";
 					pairs: [
 						[
 							"Can I come a day early to offset jetlag?",
-							"We can have you speak on the second day. We don't have the budget to cover your hotel, but you can always arrange that with the hotel on your own.",
+							"We're expecting speakers to arrive the day before the conference and sleep at the hotel the night before. We can also have you speak on the second day if you prefer. We don't have the budget to cover an additional early day, but you can always arrange that with the hotel on your own.",
 						],
 						[
 							"Do I need to bring my own laptop?",


### PR DESCRIPTION
## Overview

Adds a few FAQs for international speakers. These are points we've talked about internally & shared with some folks, but not yet explicitly mentioned on the website.

Sparked by this thread with @Erioldoesdesign in our Discord: https://discord.com/channels/1181983343387099207/1244808425762848938

They're at the bottom of `/articles/speaker-guide`, under FAQs > Travel.