### PR TITLE
fix: default theme to dark

### DIFF
--- a/src/components/ThemeSetting.astro
+++ b/src/components/ThemeSetting.astro
@@ -3,12 +3,6 @@
 	const toggles = () => document.querySelectorAll(".theme-toggle");
 	const initializedToggles = new Set<Element>();
 
-	function getThemePreference() {
-		return matchMedia("(prefers-color-scheme: dark)").matches
-			? "dark"
-			: "light";
-	}
-
 	function updateElementsForTheme(newTheme: string | string) {
 		if (!newTheme || newTheme === "light") {
 			html().classList.remove("dark");
@@ -27,7 +21,7 @@
 				? (localStorage.getItem("theme") as string)
 				: undefined;
 
-		const theme = startingTheme ?? getThemePreference();
+		const theme = startingTheme ?? "dark";
 
 		updateElementsForTheme(theme);
 


### PR DESCRIPTION
Default first-time visitors to dark mode instead of their system preference 🌔. Still preserves explicit light and dark selections in local storage across refreshes.

It still hurts me that there's no way (that I know of?) to distinguish between _"no preference"_ and _"prefers light mode"_.